### PR TITLE
Changed arch selection for all architectures with 'all' flag

### DIFF
--- a/sqlite-android/src/main/jni/Application.mk
+++ b/sqlite-android/src/main/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_STL:=stlport_static
 APP_OPTIM := release
-APP_ABI := armeabi-v7a,arm64-v8a,x86,x86_64
+APP_ABI := all
 NDK_TOOLCHAIN_VERSION := clang
 NDK_APP_LIBS_OUT=../jniLibs


### PR DESCRIPTION
Similar to #17 I need all arch support for various reasons. The most important is that we actually appear to have some users on mips devices using our product.