### PR TITLE
Update to SQLite 3.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 3.20.1
+
+- [SQLite 3.20.1](https://sqlite.org/releaselog/3_20_1.html)
+
 ## 3.20.0
 
 - [SQLite 3.20.0](https://sqlite.org/releaselog/3_20_0.html)

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -56,7 +56,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2017/sqlite-amalgamation-3200000.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2017/sqlite-amalgamation-3200100.zip'
     pomXml = {
         resolveStrategy = Closure.DELEGATE_FIRST
         name project.name

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.jfrog.bintray'
 import de.undercouch.gradle.tasks.download.Download
 
 group = 'io.requery'
-version = '3.20.0'
+version = '3.20.1'
 description = 'Android SQLite compatibility library'
 
 gradle.projectsEvaluated {


### PR DESCRIPTION
SQLite has released [Version 3.20.1](https://www.sqlite.org/releaselog/3_20_1.html]. It seems like this is all that's required to update?

#43 