### PR TITLE
Remove NULL Check From CursorWindow#getString

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
@@ -266,11 +266,7 @@ public class CursorWindow extends SQLiteClosable {
      * @return The value of the field as a string.
      */
     public String getString(int row, int column) {
-        String value = nativeGetString(mWindowPtr, row - mStartPos, column);
-        if (value == null) {
-            return "";
-        }
-        return value;
+        return nativeGetString(mWindowPtr, row - mStartPos, column);
     }
 
     /**


### PR DESCRIPTION
Android's SQLite `CursorWindow#getString` returns `null` values, but the version here doesn't: this causes problems with apps that were coded against Android's version.