### PR TITLE
Add more verbose error message when loading native extension

### DIFF
--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
@@ -819,6 +819,8 @@ static jboolean nativeHasCodec(JNIEnv* env, jobject clazz){
 
 static void nativeLoadExtension(JNIEnv* env, jobject clazz,
                                 jlong connectionPtr, jstring file, jstring proc) {
+    char* errorMessage;
+
     SQLiteConnection* connection = reinterpret_cast<SQLiteConnection*>(connectionPtr);
     int result = sqlite3_enable_load_extension(connection->db, 1);
     if (result == SQLITE_OK) {
@@ -827,14 +829,18 @@ static void nativeLoadExtension(JNIEnv* env, jobject clazz,
         if (proc) {
             procChars = env->GetStringUTFChars(proc, NULL);
         }
-        result = sqlite3_load_extension(connection->db, fileChars, procChars, 0);
+        result = sqlite3_load_extension(connection->db, fileChars, procChars, &errorMessage);
         env->ReleaseStringUTFChars(file, fileChars);
         if (proc) {
             env->ReleaseStringUTFChars(proc, procChars);
         }
     }
     if (result != SQLITE_OK) {
+        char* formattedError = sqlite3_mprintf("Could not register extension: %s", errorMessage);
+        sqlite3_free(errorMessage);
+
         throw_sqlite3_exception_errcode(env, result, "Could not register extension");
+        sqlite3_free(formattedError);
     }
 }
 

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
@@ -839,7 +839,7 @@ static void nativeLoadExtension(JNIEnv* env, jobject clazz,
         char* formattedError = sqlite3_mprintf("Could not register extension: %s", errorMessage);
         sqlite3_free(errorMessage);
 
-        throw_sqlite3_exception_errcode(env, result, "Could not register extension");
+        throw_sqlite3_exception_errcode(env, result, formattedError);
         sqlite3_free(formattedError);
     }
 }


### PR DESCRIPTION
I'm working on adding FTS5 support to an app using the SQLite support library as well as some custom tokenizers. These changes make it a little easier to see what's going wrong under the hood.