### PR TITLE
update to SQLite 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+## 3.22.0
+
+- [SQLite 3.22.0](https://sqlite.org/releaselog/3_22_0.html)
+- Update `android.arch.persistence:db` dependency to `1.0.0`
+- Improved error messaging on loading custom extensions
+- Increase CursorWindow size to match AOSP
+- Add custom extension and function loading to new SupportSQLiteDatabase API
+
 ## 3.21.0
 
 - [SQLite 3.21.0](https://sqlite.org/releaselog/3_21_0.html)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage
 
 ```gradle
 dependencies {
-    compile 'io.requery:sqlite-android:3.20.0'
+    compile 'io.requery:sqlite-android:3.22.0'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.jfrog.bintray'
 import de.undercouch.gradle.tasks.download.Download
 
 group = 'io.requery'
-version = '3.21.0'
+version = '3.22.0'
 description = 'Android SQLite compatibility library'
 
 gradle.projectsEvaluated {
@@ -55,7 +55,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2017/sqlite-amalgamation-3210000.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3220000.zip'
     pomXml = {
         resolveStrategy = Closure.DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
SQLite `3.22` is out! That means we can also flush the queue of features waiting to go out with a new version of the lib!