### PR TITLE
Allow passing flags used when registering Functions

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
@@ -902,8 +902,22 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
      * @hide
      */
     public void addFunction(String name, int numArgs, Function function) {
+        addFunction(name, numArgs, function, 0);
+    }
+
+    /**
+     * Registers a Function callback as a function that can be called from
+     * SQLite database triggers.
+     *
+     * @param name the name of the sqlite3 function
+     * @param numArgs the number of arguments for the function
+     * @param function callback to call when the function is executed
+     * @param flags 
+     * @hide
+     */
+    public void addFunction(String name, int numArgs, Function function, int flags) {
         // Create wrapper (also validates arguments).
-        SQLiteFunction wrapper = new SQLiteFunction(name, numArgs, function);
+        SQLiteFunction wrapper = new SQLiteFunction(name, numArgs, function, flags);
 
         synchronized (mLock) {
             throwIfNotOpenLocked();
@@ -2407,6 +2421,12 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
      * that can be called from sqlite3 database triggers, or used in queries.
      */
     public interface Function {
+        /**
+         * Flag that declares this function to be "deterministic,"
+         *  which means it may be used with Indexes on Expressions.
+         */
+        public static final int FLAG_DETERMINISTIC = 0x800;
+
         interface Args {
             byte[] getBlob(int arg);
             String getString(int arg);

--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteFunction.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteFunction.java
@@ -8,6 +8,9 @@ public class SQLiteFunction {
     public final int numArgs;
     public final SQLiteDatabase.Function callback;
 
+    // accessed from native code
+    final int flags;
+
     // NOTE: from a single database connection, all calls to
     // functions are serialized by SQLITE-internal mutexes,
     // so we save on GC churn by reusing a single, shared instance
@@ -21,9 +24,27 @@ public class SQLiteFunction {
      * @param numArgs The number of arguments for the function, or -1 to
      * support any number of arguments.
      * @param callback The callback to invoke when the function is executed.
+     * @param flags Extra SQLITE flags to pass when creating the function
+     * in native code.
      */
     public SQLiteFunction(String name, int numArgs,
             SQLiteDatabase.Function callback) {
+        this(name, numArgs, callback, 0);
+    }
+
+    /**
+     * Create custom function.
+     *
+     * @param name The name of the sqlite3 function.
+     * @param numArgs The number of arguments for the function, or -1 to
+     * support any number of arguments.
+     * @param callback The callback to invoke when the function is executed.
+     * @param flags Extra SQLITE flags to pass when creating the function
+     * in native code.
+     */
+    public SQLiteFunction(String name, int numArgs,
+            SQLiteDatabase.Function callback,
+            int flags) {
         if (name == null) {
             throw new IllegalArgumentException("name must not be null.");
         }
@@ -31,6 +52,7 @@ public class SQLiteFunction {
         this.name = name;
         this.numArgs = numArgs;
         this.callback = callback;
+        this.flags = flags;
     }
 
     // Called from native.

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
@@ -61,6 +61,7 @@ static struct {
 static struct {
     jfieldID name;
     jfieldID numArgs;
+    jfieldID flags;
     jmethodID dispatchCallback;
 } gSQLiteFunctionClassInfo;
 
@@ -339,11 +340,13 @@ static void nativeRegisterFunction(JNIEnv *env, jclass clazz, jlong connectionPt
     jstring nameStr = jstring(env->GetObjectField(
             functionObj, gSQLiteFunctionClassInfo.name));
     jint numArgs = env->GetIntField(functionObj, gSQLiteFunctionClassInfo.numArgs);
+    jint flags = env->GetIntField(functionObj, gSQLiteFunctionClassInfo.flags);
 
     jobject functionObjGlobal = env->NewGlobalRef(functionObj);
 
     const char* name = env->GetStringUTFChars(nameStr, NULL);
-    int err = sqlite3_create_function_v2(connection->db, name, numArgs, SQLITE_UTF16,
+    int err = sqlite3_create_function_v2(connection->db, name, numArgs,
+                                         SQLITE_UTF16 | flags,
                                          reinterpret_cast<void*>(functionObjGlobal),
                                          &sqliteFunctionCallback, NULL, NULL, &sqliteCustomFunctionDestructor);
     env->ReleaseStringUTFChars(nameStr, name);
@@ -991,6 +994,8 @@ int register_android_database_SQLiteConnection(JNIEnv *env)
             "name", "Ljava/lang/String;");
     GET_FIELD_ID(gSQLiteFunctionClassInfo.numArgs, clazz,
             "numArgs", "I");
+    GET_FIELD_ID(gSQLiteFunctionClassInfo.flags, clazz,
+            "flags", "I");
     GET_METHOD_ID(gSQLiteFunctionClassInfo.dispatchCallback,
             clazz, "dispatchCallback", "(JJI)V");
 


### PR DESCRIPTION
In particular, this lets us pass the SQLITE_DETERMINISTIC flag
(copied for convenience as `Function.FLAG_DETERMINISTIC`) which should
let our custom functions be used with Indexes on Expressions. Knowing
that a function is deterministic supposedly also lets sqlite make
other optimizations.