### PR TITLE
Update SQLite to 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 3.24.0
+
+- [SQLite 3.24.0](http://sqlite.org/releaselog/3_24_0.html)
+
 ## 3.23.1
 
 - [SQLite 3.23.1](http://sqlite.org/releaselog/3_23_1.html)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage
 
 ```gradle
 dependencies {
-    compile 'io.requery:sqlite-android:3.23.1'
+    compile 'io.requery:sqlite-android:3.24.0'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }

--- a/sqlite-android/.gitignore
+++ b/sqlite-android/.gitignore
@@ -4,3 +4,4 @@
 /src/main/jni/sqlite/sqlite3.c
 /src/main/jni/sqlite.zip
 /src/main/obj
+.externalNativeBuild/

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.jfrog.bintray'
 import de.undercouch.gradle.tasks.download.Download
 
 group = 'io.requery'
-version = '3.23.1'
+version = '3.24.0'
 description = 'Android SQLite compatibility library'
 
 android {
@@ -54,7 +54,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3230100.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3240000.zip'
     pomXml = {
         resolveStrategy = Closure.DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
I had to put `google()` before `jcenter()` to fix this error:

```
Could not resolve all files for configuration ':sqlite-android:debugCompileClasspath'.
> Could not find common.jar (android.arch.core:common:1.0.0).
  Searched in the following locations:
      https://jcenter.bintray.com/android/arch/core/common/1.0.0/common-1.0.0.jar
```