### PR TITLE
Remove MIPS from list of platforms (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ The native library is built for the following CPU architectures:
 - `arm64-v8a`
 - `x86`
 - `x86_64`
-- `mips`
 
 However you may not want to include all binaries in your apk. You can exclude certain variants by
 using `packagingOptions`:


### PR DESCRIPTION
In #65 MIPS ABI was removed, the docs should be updated to reflect that