### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 android:
   components:
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.2
     - android-21
     - android-26
     - sys-img-armeabi-v7a-android-21

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
+        classpath 'org.apache.httpcomponents:httpclient:4.5.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Sep 22 20:39:18 ECT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -1,21 +1,18 @@
 plugins {
-    id 'de.undercouch.download' version '2.1.0'
+    id 'de.undercouch.download' version '3.4.3'
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-apply plugin: 'de.undercouch.download'
 apply plugin: 'com.jfrog.bintray'
-
-import de.undercouch.gradle.tasks.download.Download
 
 group = 'io.requery'
 version = '3.24.0'
 description = 'Android SQLite compatibility library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         minSdkVersion 14
@@ -44,10 +41,10 @@ android {
 }
 
 dependencies {
-    implementation 'android.arch.persistence:db:1.0.0'
-    implementation 'com.android.support:support-core-utils:26.1.0'
-    androidTestImplementation 'com.android.support.test:runner:0.5'
-    androidTestImplementation 'com.android.support.test:rules:0.5'
+    implementation 'android.arch.persistence:db:1.1.1'
+    implementation 'com.android.support:support-core-utils:28.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }
 
 publish.dependsOn "assembleRelease"
@@ -56,7 +53,7 @@ bintrayUpload.dependsOn "assembleRelease"
 ext {
     sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3240000.zip'
     pomXml = {
-        resolveStrategy = Closure.DELEGATE_FIRST
+        resolveStrategy = DELEGATE_FIRST
         name project.name
         description project.description
         url 'https://github.com/requery/sqlite-android'

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -5,6 +5,7 @@ plugins {
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'de.undercouch.download'
 
 group = 'io.requery'
 version = '3.24.0'

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
@@ -17,13 +17,19 @@
 
 package io.requery.android.database;
 
-import android.test.PerformanceTestCase;
-import android.test.suitebuilder.annotation.SmallTest;
-import junit.framework.TestCase;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 
-public class CursorWindowTest extends TestCase implements PerformanceTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class CursorWindowTest {
     static {
         System.loadLibrary("sqlite3x");
     }
@@ -31,12 +37,8 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
         return false;
     }
 
-    // These test can only be run once.
-    public int startPerformance(Intermediates intermediates) {
-        return 1;
-    }
-
     @SmallTest
+    @Test
     public void testConstructor_WithName() {
         CursorWindow window = new CursorWindow("MyWindow");
         assertEquals("MyWindow", window.getName());
@@ -45,6 +47,7 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
     }
 
     @SmallTest
+    @Test
     public void testConstructorWithEmptyName() {
         CursorWindow window = new CursorWindow("");
         assertEquals("<unnamed>", window.getName());
@@ -53,6 +56,7 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
     }
 
     @SmallTest
+    @Test
     public void testConstructorWithNullName() {
         CursorWindow window = new CursorWindow(null);
         assertEquals("<unnamed>", window.getName());
@@ -61,6 +65,7 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
     }
 
     @SmallTest
+    @Test
     public void testValues() {
         CursorWindow window = new CursorWindow("MyWindow");
         doTestValues(window);
@@ -73,7 +78,7 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
         double db1 = 1.26;
         assertTrue(window.putDouble(db1, 0, 0));
         double db2 = window.getDouble(0, 0);
-        assertEquals(db1, db2);
+        assertEquals(db1, db2, 0);
 
         long int1 = Long.MAX_VALUE;
         assertTrue(window.putLong(int1, 0, 1));
@@ -90,7 +95,7 @@ public class CursorWindowTest extends TestCase implements PerformanceTestCase {
         
         assertTrue(window.putString(Double.toString(42.0), 0, 4));
         assertEquals(Double.toString(42.0), window.getString(0, 4));
-        assertEquals(42.0, window.getDouble(0, 4));
+        assertEquals(42.0, window.getDouble(0, 4), 0);
         
         // put blob
         byte[] blob = new byte[1000];

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseGeneralTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseGeneralTest.java
@@ -24,16 +24,21 @@ import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteException;
 import android.os.Parcel;
-import android.test.AndroidTestCase;
-import android.test.PerformanceTestCase;
-import android.test.suitebuilder.annotation.LargeTest;
-import android.test.suitebuilder.annotation.MediumTest;
-import android.test.suitebuilder.annotation.SmallTest;
-import android.test.suitebuilder.annotation.Suppress;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.LargeTest;
+import android.support.test.filters.MediumTest;
+import android.support.test.filters.SmallTest;
+import android.support.test.filters.Suppress;
+import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import android.util.Pair;
 
 import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -44,8 +49,16 @@ import java.util.Locale;
 import io.requery.android.database.sqlite.SQLiteDatabase;
 import io.requery.android.database.sqlite.SQLiteStatement;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 @SuppressWarnings({"deprecated", "ResultOfMethodCallIgnored"})
-public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceTestCase {
+@RunWith(AndroidJUnit4.class)
+public class DatabaseGeneralTest {
     private static final String TAG = "DatabaseGeneralTest";
 
     private static final String sString1 = "this is a test";
@@ -57,10 +70,9 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     private SQLiteDatabase mDatabase;
     private File mDatabaseFile;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        File dbDir = getContext().getDir(this.getClass().getName(), Context.MODE_PRIVATE);
+    @Before
+    public void setUp() {
+        File dbDir = InstrumentationRegistry.getTargetContext().getDir(this.getClass().getName(), Context.MODE_PRIVATE);
         mDatabaseFile = new File(dbDir, "database_test.db");
         if (mDatabaseFile.exists()) {
             mDatabaseFile.delete();
@@ -70,20 +82,14 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         mDatabase.setVersion(CURRENT_DATABASE_VERSION);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         mDatabase.close();
         mDatabaseFile.delete();
-        super.tearDown();
     }
 
     public boolean isPerformanceOnly() {
         return false;
-    }
-
-    // These test can only be run once.
-    public int startPerformance(Intermediates intermediates) {
-        return 1;
     }
 
     private void populateDefaultTable() {
@@ -95,6 +101,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testCustomFunction() {
         mDatabase.addCustomFunction("roundFunction", 1, new SQLiteDatabase.CustomFunction() {
             @Override
@@ -111,6 +118,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testNewFunction() {
         mDatabase.addFunction("roundFunction2", 1, new SQLiteDatabase.Function() {
             @Override
@@ -126,6 +134,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testCustomFunctionNoReturn() {
         mDatabase.addCustomFunction("emptyFunction", 1, new SQLiteDatabase.CustomFunction() {
             @Override
@@ -140,6 +149,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testNewFunctionNoReturn() {
         mDatabase.addFunction("emptyFunction2", 1, new SQLiteDatabase.Function() {
             @Override
@@ -153,14 +163,16 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testVersion() throws Exception {
+    @Test
+    public void testVersion() {
         assertEquals(CURRENT_DATABASE_VERSION, mDatabase.getVersion());
         mDatabase.setVersion(11);
         assertEquals(11, mDatabase.getVersion());
     }
 
     @MediumTest
-    public void testUpdate() throws Exception {
+    @Test
+    public void testUpdate() {
         populateDefaultTable();
 
         ContentValues values = new ContentValues(1);
@@ -175,7 +187,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSupportUpdate() throws Exception {
+    @Test
+    public void testSupportUpdate() {
         populateDefaultTable();
 
         ContentValues values = new ContentValues(1);
@@ -191,7 +204,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSupportDelete() throws Exception {
+    @Test
+    public void testSupportDelete() {
         populateDefaultTable();
 
         assertEquals(1, mDatabase.delete("test", "_id=?", new Object[] { 1 }));
@@ -202,7 +216,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
 
     @Suppress // PHONE_NUMBERS_EQUAL not supported
     @MediumTest
-    public void testPhoneNumbersEqual() throws Exception {
+    @Test
+    public void testPhoneNumbersEqual() {
         mDatabase.execSQL("CREATE TABLE phones (num TEXT);");
         mDatabase.execSQL("INSERT INTO phones (num) VALUES ('911');");
         mDatabase.execSQL("INSERT INTO phones (num) VALUES ('5555');");
@@ -325,13 +340,12 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         }
     }
 
-    private void assertPhoneNumberEqual(String phone1, String phone2) throws Exception {
+    private void assertPhoneNumberEqual(String phone1, String phone2) {
         assertPhoneNumberEqual(phone1, phone2, true);
         assertPhoneNumberEqual(phone1, phone2, false);
     }
     
-    private void assertPhoneNumberEqual(String phone1, String phone2, boolean useStrict)
-            throws Exception {
+    private void assertPhoneNumberEqual(String phone1, String phone2, boolean useStrict) {
         phoneNumberCompare(phone1, phone2, true, useStrict);
     }
 
@@ -352,6 +366,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
      */
     @Suppress // PHONE_NUMBERS_EQUAL not supported
     @SmallTest
+    @Test
     public void testPhoneNumbersEqualInternationl() throws Exception {
         assertPhoneNumberEqual("1", "1");
         assertPhoneNumberEqual("123123", "123123");
@@ -408,6 +423,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testCopyString() throws Exception {
         mDatabase.execSQL("CREATE TABLE guess (numi INTEGER, numf FLOAT, str TEXT);");
         mDatabase.execSQL(
@@ -448,7 +464,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         
         c.moveToNext();
         c.copyStringToBuffer(numfIdx, buf);
-        assertEquals(-1.0, Double.valueOf(
+        assertEquals(new Double(-1.0), Double.valueOf(
             new String(buf.data, 0, buf.sizeCopied)));
         
         c.copyStringToBuffer(strIdx, buf);
@@ -460,6 +476,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
     
     @MediumTest
+    @Test
     public void testSchemaChange1() throws Exception {
         SQLiteDatabase db1 = mDatabase;
         Cursor cursor;
@@ -476,7 +493,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSchemaChange2() throws Exception {
+    @Test
+    public void testSchemaChange2() {
         mDatabase.execSQL("CREATE TABLE db1 (_id INTEGER PRIMARY KEY, data TEXT);");
         Cursor cursor = mDatabase.query("db1", null, null, null, null, null, null);
         assertNotNull(cursor);
@@ -485,7 +503,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSchemaChange3() throws Exception {
+    @Test
+    public void testSchemaChange3() {
         mDatabase.execSQL("CREATE TABLE db1 (_id INTEGER PRIMARY KEY, data TEXT);");
         mDatabase.execSQL("INSERT INTO db1 (data) VALUES ('test');");
         mDatabase.execSQL("ALTER TABLE db1 ADD COLUMN blah int;");
@@ -502,7 +521,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSelectionArgs() throws Exception {
+    @Test
+    public void testSelectionArgs() {
         mDatabase.execSQL("CREATE TABLE test (_id INTEGER PRIMARY KEY, data TEXT);");
         ContentValues values = new ContentValues(1);
         values.put("data", "don't forget to handled 's");
@@ -520,7 +540,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
 
     @Suppress // unicode collator not supported yet
     @MediumTest
-    public void testTokenize() throws Exception {
+    @Test
+    public void testTokenize() {
         Cursor c;
         mDatabase.execSQL("CREATE TABLE tokens (" +
                 "token TEXT COLLATE unicode," +
@@ -692,7 +713,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
     
     @MediumTest
-    public void testTransactions() throws Exception {
+    @Test
+    public void testTransactions() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER);");
         mDatabase.execSQL("INSERT INTO test (num) VALUES (0)");
 
@@ -795,7 +817,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testContentValues() throws Exception {
+    @Test
+    public void testContentValues() {
         ContentValues values = new ContentValues();
         values.put("string", "value");
         assertEquals("value", values.getAsString("string"));
@@ -819,7 +842,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     public static final int TABLE_INFO_PRAGMA_DEFAULT_INDEX = 4;
 
     @MediumTest
-    public void testTableInfoPragma() throws Exception {
+    @Test
+    public void testTableInfoPragma() {
         mDatabase.execSQL("CREATE TABLE pragma_test (" +
                 "i INTEGER DEFAULT 1234, " +
                 "j INTEGER, " +
@@ -868,7 +892,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
-    public void testSemicolonsInStatements() throws Exception {
+    @Test
+    public void testSemicolonsInStatements() {
         mDatabase.execSQL("CREATE TABLE pragma_test (" +
                 "i INTEGER DEFAULT 1234, " +
                 "j INTEGER, " +
@@ -888,6 +913,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @MediumTest
+    @Test
     public void testUnionsWithBindArgs() {
         /* make sure unions with bindargs work http://b/issue?id=1061291 */
         mDatabase.execSQL("CREATE TABLE A (i int);");
@@ -921,7 +947,8 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
      */
     @Suppress
     @MediumTest
-    public void testCollateLocalizedForJapanese() throws Exception {
+    @Test
+    public void testCollateLocalizedForJapanese() {
         final String testName = "DatabaseGeneralTest#testCollateLocalizedForJapanese()";
         final Locale[] localeArray = Locale.getAvailableLocales();
         final String japanese = Locale.JAPANESE.getLanguage();
@@ -1004,6 +1031,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @SmallTest
+    @Test
     public void testSetMaxCacheSize() {
         mDatabase.execSQL("CREATE TABLE test (i int, j int);");
         mDatabase.execSQL("insert into test values(1,1);");
@@ -1020,6 +1048,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
     }
 
     @LargeTest
+    @Test
     public void testDefaultDatabaseErrorHandler() {
         DefaultDatabaseErrorHandler errorHandler = new DefaultDatabaseErrorHandler();
 

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseLocaleTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseLocaleTest.java
@@ -18,18 +18,28 @@
 package io.requery.android.database;
 
 import android.database.Cursor;
-import android.test.MoreAsserts;
-import android.test.suitebuilder.annotation.MediumTest;
-import android.test.suitebuilder.annotation.SmallTest;
-import android.test.suitebuilder.annotation.Suppress;
+import android.support.test.filters.MediumTest;
+import android.support.test.filters.SmallTest;
+import android.support.test.filters.Suppress;
+import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import io.requery.android.database.sqlite.SQLiteDatabase;
-import junit.framework.TestCase;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Locale;
 
-public class DatabaseLocaleTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class DatabaseLocaleTest {
 
     private SQLiteDatabase mDatabase;
 
@@ -43,9 +53,8 @@ public class DatabaseLocaleTest extends TestCase {
         "COTE",
     };
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() {
         mDatabase = SQLiteDatabase.create(null);
         mDatabase.execSQL(
                 "CREATE TABLE test (id INTEGER PRIMARY KEY, data TEXT COLLATE LOCALIZED);");
@@ -57,16 +66,15 @@ public class DatabaseLocaleTest extends TestCase {
         }
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         mDatabase.close();
-        super.tearDown();
     }
 
     private String[] query(String sql) {
         Log.i("LocaleTest", "Querying: " + sql);
         Cursor c = mDatabase.rawQuery(sql, null);
-        assertNotNull(c);
+        Assert.assertNotNull(c);
         ArrayList<String> items = new ArrayList<>();
         while (c.moveToNext()) {
             items.add(c.getString(0));
@@ -79,15 +87,17 @@ public class DatabaseLocaleTest extends TestCase {
     }
 
     @MediumTest
-    public void testLocaleInsertOrder() throws Exception {
+    @Test
+    public void testLocaleInsertOrder() {
         insertStrings();
         String[] results = query("SELECT data FROM test");
-        MoreAsserts.assertEquals(STRINGS, results);
+        assertEquals(STRINGS, results);
     }
 
     @Suppress // not supporting localized collators
     @MediumTest
-    public void testLocaleenUS() throws Exception {
+    @Test
+    public void testLocaleenUS() {
         insertStrings();
         Log.i("LocaleTest", "about to call setLocale en_US");
         mDatabase.setLocale(new Locale("en", "US"));
@@ -97,7 +107,7 @@ public class DatabaseLocaleTest extends TestCase {
         // The database code currently uses PRIMARY collation strength,
         // meaning that all versions of a character compare equal (regardless
         // of case or accents), leaving the "cote" flavors in database order.
-        MoreAsserts.assertEquals(results, new String[] {
+        assertEquals(results, new String[] {
                 STRINGS[4],  // "boy"
                 STRINGS[0],  // sundry forms of "cote"
                 STRINGS[1],
@@ -109,6 +119,7 @@ public class DatabaseLocaleTest extends TestCase {
     }
 
     @SmallTest
+    @Test
     public void testHoge() throws Exception {
         Cursor cursor = null;
         try {

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseStatementTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/DatabaseStatementTest.java
@@ -21,16 +21,28 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteConstraintException;
 import android.database.sqlite.SQLiteDoneException;
-import android.test.AndroidTestCase;
-import android.test.PerformanceTestCase;
-import android.test.suitebuilder.annotation.MediumTest;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.MediumTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import io.requery.android.database.sqlite.SQLiteDatabase;
 import io.requery.android.database.sqlite.SQLiteStatement;
 
 import java.io.File;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 @SuppressWarnings("ResultOfMethodCallIgnored")
-public class DatabaseStatementTest extends AndroidTestCase implements PerformanceTestCase {
+@RunWith(AndroidJUnit4.class)
+public class DatabaseStatementTest {
 
     private static final String sString1 = "this is a test";
     private static final String sString2 = "and yet another test";
@@ -40,10 +52,9 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     private SQLiteDatabase mDatabase;
     private File mDatabaseFile;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        File dbDir = getContext().getDir("tests", Context.MODE_PRIVATE);
+    @Before
+    public void setUp() {
+        File dbDir = InstrumentationRegistry.getTargetContext().getDir("tests", Context.MODE_PRIVATE);
         mDatabaseFile = new File(dbDir, "database_test.db");
 
         if (mDatabaseFile.exists()) {
@@ -54,20 +65,14 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
         mDatabase.setVersion(CURRENT_DATABASE_VERSION);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         mDatabase.close();
         mDatabaseFile.delete();
-        super.tearDown();
     }
 
     public boolean isPerformanceOnly() {
         return false;
-    }
-
-    // These test can only be run once.
-    public int startPerformance(Intermediates intermediates) {
-        return 1;
     }
 
     private void populateDefaultTable() {
@@ -79,7 +84,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testExecuteStatement() throws Exception {
+    @Test
+    public void testExecuteStatement() {
         populateDefaultTable();
         SQLiteStatement statement = mDatabase.compileStatement("DELETE FROM test");
         statement.execute();
@@ -91,7 +97,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testSimpleQuery() throws Exception {
+    @Test
+    public void testSimpleQuery() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER NOT NULL, str TEXT NOT NULL);");
         mDatabase.execSQL("INSERT INTO test VALUES (1234, 'hello');");
         SQLiteStatement statement1 =
@@ -128,7 +135,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testStatementLongBinding() throws Exception {
+    @Test
+    public void testStatementLongBinding() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER);");
         SQLiteStatement statement = mDatabase.compileStatement("INSERT INTO test (num) VALUES (?)");
 
@@ -150,7 +158,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testStatementStringBinding() throws Exception {
+    @Test
+    public void testStatementStringBinding() {
         mDatabase.execSQL("CREATE TABLE test (num TEXT);");
         SQLiteStatement statement = mDatabase.compileStatement("INSERT INTO test (num) VALUES (?)");
 
@@ -172,7 +181,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testStatementClearBindings() throws Exception {
+    @Test
+    public void testStatementClearBindings() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER);");
         SQLiteStatement statement = mDatabase.compileStatement("INSERT INTO test (num) VALUES (?)");
 
@@ -194,7 +204,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testSimpleStringBinding() throws Exception {
+    @Test
+    public void testSimpleStringBinding() {
         mDatabase.execSQL("CREATE TABLE test (num TEXT, value TEXT);");
         String statement = "INSERT INTO test (num, value) VALUES (?,?)";
 
@@ -218,7 +229,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testStatementMultipleBindings() throws Exception {
+    @Test
+    public void testStatementMultipleBindings() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER, str TEXT);");
         SQLiteStatement statement =
                 mDatabase.compileStatement("INSERT INTO test (num, str) VALUES (?, ?)");
@@ -248,7 +260,7 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
         private SQLiteDatabase mDatabase;
         private SQLiteStatement mStatement;
 
-        public StatementTestThread(SQLiteDatabase db, SQLiteStatement statement) {
+        private StatementTestThread(SQLiteDatabase db, SQLiteStatement statement) {
             super();
             mDatabase = db;
             mStatement = statement;
@@ -281,6 +293,7 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
+    @Test
     public void testStatementMultiThreaded() throws Exception {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER, str TEXT);");
         SQLiteStatement statement =
@@ -296,7 +309,8 @@ public class DatabaseStatementTest extends AndroidTestCase implements Performanc
     }
 
     @MediumTest
-    public void testStatementConstraint() throws Exception {
+    @Test
+    public void testStatementConstraint() {
         mDatabase.execSQL("CREATE TABLE test (num INTEGER NOT NULL);");
         SQLiteStatement statement = mDatabase.compileStatement("INSERT INTO test (num) VALUES (?)");
 

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/NewDatabasePerformanceTestSuite.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/NewDatabasePerformanceTestSuite.java
@@ -17,10 +17,14 @@
 
 package io.requery.android.database;
 
+import android.support.test.runner.AndroidJUnit4;
+
 import junit.framework.TestSuite;
 import org.junit.Ignore;
+import org.junit.runner.RunWith;
 
 @Ignore
+@RunWith(AndroidJUnit4.class)
 public class NewDatabasePerformanceTestSuite extends TestSuite {
 
     public static TestSuite suite() {

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/NewDatabasePerformanceTests.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/NewDatabasePerformanceTests.java
@@ -19,12 +19,21 @@ package io.requery.android.database;
 
 import android.annotation.SuppressLint;
 import android.content.ContentValues;
-import android.test.PerformanceTestCase;
-import io.requery.android.database.sqlite.SQLiteDatabase;
+import android.support.test.runner.AndroidJUnit4;
+
 import junit.framework.TestCase;
+
+import io.requery.android.database.sqlite.SQLiteDatabase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.Random;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Database Performance Tests
@@ -35,14 +44,14 @@ public class NewDatabasePerformanceTests {
     // Edit this to change the test run times.  The original is 100.
     final static int kMultiplier = 1;
 
-    public static class PerformanceBase extends TestCase
-    implements PerformanceTestCase {
+    public static class PerformanceBase extends TestCase {
         protected static final int CURRENT_DATABASE_VERSION = 42;
         protected SQLiteDatabase mDatabase;
         protected File mDatabaseFile;
 
         @SuppressWarnings("ResultOfMethodCallIgnored")
         @SuppressLint("SdCardPath")
+        @Before
         public void setUp() {
             mDatabaseFile = new File("/sdcard", "perf_database_test.db");
             if (mDatabaseFile.exists()) {
@@ -56,18 +65,10 @@ public class NewDatabasePerformanceTests {
         }
 
         @SuppressWarnings("ResultOfMethodCallIgnored")
+        @After
         public void tearDown() {
             mDatabase.close();
             mDatabaseFile.delete();
-        }
-
-        public boolean isPerformanceOnly() {
-            return true;
-        }
-
-        // These tests can only be run once.
-        public int startPerformance(Intermediates intermediates) {
-            return 0;
         }
 
         public String numberName(int number) {
@@ -111,7 +112,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] statements = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -127,6 +128,7 @@ public class NewDatabasePerformanceTests {
             .execSQL("CREATE TABLE t1(a INTEGER, b INTEGER, c VARCHAR(100))");
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.execSQL(statements[i]);
@@ -143,7 +145,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] statements = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -160,6 +162,7 @@ public class NewDatabasePerformanceTests {
             mDatabase.execSQL("CREATE INDEX i1c ON t1(c)");
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.execSQL(statements[i]);
@@ -177,7 +180,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -198,6 +201,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -216,7 +220,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -235,6 +239,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -253,7 +258,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -275,6 +280,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -291,7 +297,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"t1.a"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -314,6 +320,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             mDatabase.query("t1 INNER JOIN t2 ON t1.b = t2.b", COLUMNS, null,
                     null, null, null, null);
@@ -328,7 +335,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"t1.a"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -353,6 +360,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             mDatabase.query("t1 INNER JOIN t2 ON t1.b = t2.b", COLUMNS, null,
                     null, null, null, null);
@@ -367,7 +375,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"t1.a"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -392,6 +400,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             mDatabase.query("t1 INNER JOIN t2 ON t1.c = t2.c", COLUMNS, null,
                     null, null, null, null);
@@ -408,7 +417,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -441,6 +450,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -459,7 +469,7 @@ public class NewDatabasePerformanceTests {
 
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -479,6 +489,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -495,7 +506,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"b"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -511,6 +522,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t1", COLUMNS, null, null, null, null, null);
@@ -526,7 +538,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"c"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -542,6 +554,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t1", COLUMNS, null, null, null, null, null);
@@ -557,7 +570,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"b"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -574,6 +587,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t1", COLUMNS, null, null, null, null, null);
@@ -589,7 +603,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = kMultiplier;
         private static final String[] COLUMNS = {"c"};
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -606,6 +620,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t1", COLUMNS, null, null, null, null, null);
@@ -622,7 +637,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"c"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -645,6 +660,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase
@@ -660,7 +676,7 @@ public class NewDatabasePerformanceTests {
     public static class DeleteIndexed1000 extends PerformanceBase {
         private static final int SIZE = 10 * kMultiplier;
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -677,6 +693,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.delete("t1", null, null);
@@ -691,7 +708,7 @@ public class NewDatabasePerformanceTests {
     public static class Delete1000 extends PerformanceBase {
         private static final int SIZE = 10 * kMultiplier;
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -707,6 +724,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.delete("t1", null, null);
@@ -722,7 +740,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 10 * kMultiplier;
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -743,6 +761,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.delete("t1", where[i], null);
@@ -758,7 +777,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 10 * kMultiplier;
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -780,6 +799,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.delete("t1", where[i], null);
@@ -796,7 +816,7 @@ public class NewDatabasePerformanceTests {
         private String[] where = new String[SIZE];
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -823,6 +843,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.update("t1", mValues[i], where[i], null);
@@ -839,7 +860,7 @@ public class NewDatabasePerformanceTests {
         private String[] where = new String[SIZE];
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -864,6 +885,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.update("t1", mValues[i], where[i], null);
@@ -879,7 +901,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 100 * kMultiplier;
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -895,6 +917,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.insert("t1", null, mValues[i]);
@@ -910,7 +933,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 100 * kMultiplier;
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -927,6 +950,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.insert("t1", null, mValues[i]);
@@ -942,7 +966,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 100 * kMultiplier;
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -958,6 +982,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.insert("t1", null, mValues[i]);
@@ -973,7 +998,7 @@ public class NewDatabasePerformanceTests {
         private static final int SIZE = 100 * kMultiplier;
         ContentValues[] mValues = new ContentValues[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -990,6 +1015,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.insert("t1", null, mValues[i]);
@@ -1007,7 +1033,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t3.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1028,6 +1054,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t3", COLUMNS, where[i], null, null, null, null);
@@ -1045,7 +1072,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t3.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1067,6 +1094,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t3", COLUMNS, where[i], null, null, null, null);
@@ -1083,7 +1111,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t4.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1100,6 +1128,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t4", COLUMNS, where[i], null, null, null, null);
@@ -1116,7 +1145,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t4.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1136,6 +1165,7 @@ public class NewDatabasePerformanceTests {
 
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t4", COLUMNS, where[i], null, null, null, null);
@@ -1153,7 +1183,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t3.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1173,6 +1203,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t3", COLUMNS, where[i], null, null, null, null);
@@ -1190,7 +1221,7 @@ public class NewDatabasePerformanceTests {
         private static final String[] COLUMNS = {"t3.a"};
         private String[] where = new String[SIZE];
 
-        @Override
+        @Before
         public void setUp() {
             super.setUp();
             Random random = new Random(42);
@@ -1211,6 +1242,7 @@ public class NewDatabasePerformanceTests {
             }
         }
 
+        @Test
         public void testRun() {
             for (int i = 0; i < SIZE; i++) {
                 mDatabase.query("t3", COLUMNS, where[i], null, null, null, null);


### PR DESCRIPTION
I noticed that many of the dependencies were very out of date, so I updated to current of everything and patched it up where needed so it seemingly ran okay for me.

The test suite is a big deal, it's an upgrade from android.test.* to AndroidJunit4Runner - a pretty big API change. Most of it is mechanical through the code but your performance test suite stuff might need a high-level think about how best to adapt.

I need to be clear that I consider the test suite suspect - on a clean master branch Travis was green but local tests fail:

```
> Task :sqlite-android:connectedDebugAndroidTest
Starting 50 tests on Nexus_5_API_21_NEW(AVD) - 5.0.2

io.requery.android.database.NewDatabasePerformanceTestSuite > null[Nexus_5_API_21_NEW(AVD) - 5.0.2] SKIPPED 

io.requery.android.database.benchmark.Benchmark > runBenchmark[Nexus_5_API_21_NEW(AVD) - 5.0.2] FAILED 
        android.database.CursorWindowAllocationException: Cursor window allocation of 2048 kb failed.
```

So, I was able to perform the changes to get the test suites converted to new APIs but I can't tell you they work. Travis is green but local testing isn't available for me to confirm :shrug:

So, this PR attempts to perform the changes but I want to add a warning that I'm not sure this works, even though Travis is telling me it's okay.

Maybe it's useful anyway?

Thanks for your help earlier with my AnkiDroid questions :-) 