### PR TITLE
Update version to 3.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 3.25.2
+
+- [SQLite 3.25.2](http://sqlite.org/releaselog/3_25_2.html)
+
 ## 3.25.1
 
 - [SQLite 3.25.1](http://sqlite.org/releaselog/3_25_1.html)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage
 
 ```gradle
 dependencies {
-    compile 'io.requery:sqlite-android:3.25.1'
+    implementation 'io.requery:sqlite-android:3.25.2'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.jfrog.bintray'
 import de.undercouch.gradle.tasks.download.Download
 
 group = 'io.requery'
-version = '3.25.1'
+version = '3.25.2'
 description = 'Android SQLite compatibility library'
 
 android {
@@ -54,7 +54,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3250100.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3250200.zip'
     pomXml = {
         resolveStrategy = Closure.DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
Upstream released 3.25.2

Would be great if #78 (mips libraries still in artifact) could be resolved before pushing this artifact out?

Thanks!