### PR TITLE
Update version to 3.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 3.25.3
+
+- [SQLite 3.25.3](http://sqlite.org/releaselog/3_25_3.html)
+
 ## 3.25.2
 
 - [SQLite 3.25.2](http://sqlite.org/releaselog/3_25_2.html)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage
 
 ```gradle
 dependencies {
-    implementation 'io.requery:sqlite-android:3.25.2'
+    implementation 'io.requery:sqlite-android:3.25.3'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'de.undercouch.download'
 
 group = 'io.requery'
-version = '3.25.2'
+version = '3.25.3'
 description = 'Android SQLite compatibility library'
 
 android {
@@ -55,7 +55,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3250200.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2018/sqlite-amalgamation-3250300.zip'
     pomXml = {
         resolveStrategy = DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
Just tracking upstream.

Note that with an API 25 and API 26 emulator running, I am not able to run connectedCheck successfully, but this is not new to this PR. It just bears mentioning as I am unsure how to verify the correctness of the work here:

```
mike@isabela:~/work/sqlite-android (upstream-3.25.3 *) % ./gradlew connectedCheck
Download http://sqlite.org/2018/sqlite-amalgamation-3250300.zip

> Task :sqlite-android:externalNativeBuildDebug
Build sqlite3x x86
make: `/home/mike/work/sqlite-android/sqlite-android/build/intermediates/ndkBuild/debug/obj/local/x86/libsqlite3x.so' is up to date.
Build sqlite3x arm64-v8a
make: `/home/mike/work/sqlite-android/sqlite-android/build/intermediates/ndkBuild/debug/obj/local/arm64-v8a/libsqlite3x.so' is up to date.
Build sqlite3x x86_64
make: `/home/mike/work/sqlite-android/sqlite-android/build/intermediates/ndkBuild/debug/obj/local/x86_64/libsqlite3x.so' is up to date.
Build sqlite3x armeabi-v7a
make: `/home/mike/work/sqlite-android/sqlite-android/build/intermediates/ndkBuild/debug/obj/local/armeabi-v7a/libsqlite3x.so' is up to date.
Starting 50 tests on Pixel_API_26_NEW(AVD) - 8.0.0
Starting 50 tests on Pixel_API_25_NEW(AVD) - 7.1.1

io.requery.android.database.NewDatabasePerformanceTestSuite > null[Pixel_API_25_NEW(AVD) - 7.1.1] SKIPPED 

io.requery.android.database.NewDatabasePerformanceTestSuite > null[Pixel_API_26_NEW(AVD) - 8.0.0] SKIPPED 

io.requery.android.database.benchmark.Benchmark > runBenchmark[Pixel_API_25_NEW(AVD) - 7.1.1] FAILED 
        android.database.CursorWindowAllocationException: Cursor window allocation of 2048 kb failed.
        at android.database.CursorWindow.<init>(CursorWindow.java:108)

> Task :sqlite-android:connectedDebugAndroidTest FAILED
```