### PR TITLE
change dependencies from implementation to api

### DIFF
--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -45,8 +45,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.sqlite:sqlite:2.0.0'
-    implementation 'androidx.core:core:1.0.0'
+    api 'androidx.sqlite:sqlite:2.0.0'
+    api 'androidx.core:core:1.0.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }


### PR DESCRIPTION
Classes of both AndroidX dependencies are exposed publicly. Therefore they aren't implementation dependencies. For androidx.core it's CancellationSignal that is part of the public API, for androidx.sqlite it's the implemented interfaces.

closes #69 