### PR TITLE
 Bump sqlite to 3.28.0,  Updated documentation about architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+## 3.28.0
+- [SQLite 3.28.0](http://sqlite.org/releaselog/3_28_0.html)
+
 ## 3.27.2
 - [SQLite 3.27.2](http://sqlite.org/releaselog/3_27_2.html)
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ using `packagingOptions`:
 ```gradle
 android {
     packagingOptions {
+        exclude 'lib/armeabi-v7a/libsqlite3x.so'
         exclude 'lib/arm64-v8a/libsqlite3x.so'
         exclude 'lib/x86/libsqlite3x.so'
         exclude 'lib/x86_64/libsqlite3x.so'
-        exclude 'lib/mips/libsqlite3x.so'
     }
 }
 ```
@@ -97,6 +97,8 @@ The size of the artifacts with only the armeabi-v7a binary is **~600kb**. In gen
 armeabi-v7a on the majority of Android devices including Intel Atom which provides a native
 translation layer, however performance under the translation layer is worse than using the x86
 binary.
+
+Note that starting August 1, 2019, your apps published on Google Play will [need to support 64-bit architectures](https://developer.android.com/distribute/best-practices/develop/64-bit).
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage
 
 ```gradle
 dependencies {
-    implementation 'io.requery:sqlite-android:3.26.0'
+    implementation 'io.requery:sqlite-android:3.28.0'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -56,7 +56,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2019/sqlite-amalgamation-3280000.zip'
+    sqliteDistributionUrl = 'https://sqlite.org/2019/sqlite-amalgamation-3280000.zip'
     pomXml = {
         resolveStrategy = DELEGATE_FIRST
         name project.name

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'de.undercouch.download'
 
 group = 'io.requery'
-version = '3.27.2'
+version = '3.28.0'
 description = 'Android SQLite compatibility library'
 
 android {
@@ -56,7 +56,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'http://sqlite.org/2019/sqlite-amalgamation-3270200.zip'
+    sqliteDistributionUrl = 'http://sqlite.org/2019/sqlite-amalgamation-3280000.zip'
     pomXml = {
         resolveStrategy = DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
sqlite 3.28.0 was not tested