### PR TITLE
Match documentation & behavior of `SQLiteDatabase.query(SupportSQLiteQuery, android.os.CancellationSignal)`

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
@@ -1348,14 +1348,18 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
     @Override
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
     public Cursor query(SupportSQLiteQuery supportQuery, android.os.CancellationSignal signal) {
-        final CancellationSignal supportCancellationSignal = new CancellationSignal();
-        signal.setOnCancelListener(new android.os.CancellationSignal.OnCancelListener() {
-            @Override
-            public void onCancel() {
-                supportCancellationSignal.cancel();
-            }
-        });
-        return query(supportQuery, supportCancellationSignal);
+        if(signal != null){
+            final CancellationSignal supportCancellationSignal = supportCancellationSignal= new CancellationSignal();
+            signal.setOnCancelListener(new android.os.CancellationSignal.OnCancelListener() {
+                @Override
+                public void onCancel() {
+                    supportCancellationSignal.cancel();
+                }
+            });
+            return query(supportQuery, supportCancellationSignal);
+        } else {
+            return query(supportQuery, null);
+        }
     }
 
     /**

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteCommon.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteCommon.cpp
@@ -112,7 +112,7 @@ void throw_sqlite3_exception(JNIEnv* env, int errcode,
             exceptionClass = "android/database/sqlite/SQLiteDatatypeMismatchException";
             break;
         case SQLITE_INTERRUPT:
-            exceptionClass = "android/support/v4/os/OperationCanceledException";
+            exceptionClass = "androidx/core/os/OperationCanceledException";
             break;
         default:
             exceptionClass = "android/database/sqlite/SQLiteException";


### PR DESCRIPTION
Providing a `null` `android.os.CancellationSignal` argument to `SupportSQLiteDatabase.query(SupportSQLiteQuery, android.os.CancellationSignal)` should not result in a NPE, but no cancellation.