### PR TITLE
Match the behavior of `SupportSQLiteDatabase.query(SupportSQLiteQuery…

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
@@ -1350,14 +1350,18 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
     @Override
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
     public Cursor query(SupportSQLiteQuery supportQuery, android.os.CancellationSignal signal) {
-        final CancellationSignal supportCancellationSignal = new CancellationSignal();
-        signal.setOnCancelListener(new android.os.CancellationSignal.OnCancelListener() {
-            @Override
-            public void onCancel() {
-                supportCancellationSignal.cancel();
-            }
-        });
-        return query(supportQuery, supportCancellationSignal);
+        if(signal != null){
+            final CancellationSignal supportCancellationSignal = supportCancellationSignal= new CancellationSignal();
+            signal.setOnCancelListener(new android.os.CancellationSignal.OnCancelListener() {
+                @Override
+                public void onCancel() {
+                    supportCancellationSignal.cancel();
+                }
+            });
+            return query(supportQuery, supportCancellationSignal);
+        } else {
+            return query(supportQuery, null);
+        }
     }
 
     /**


### PR DESCRIPTION
Providing a null android.os.CancellationSignal argument to SupportSQLiteDatabase.query(SupportSQLiteQuery, android.os.CancellationSignal) should not result in a NPE, but just skip cancellation.