### PR TITLE
Match the behavior of `SupportSQLiteDatabase.query(SupportSQLiteQuery, android.os.CancellationSignal)` to the documentation

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
@@ -1350,8 +1350,8 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
     @Override
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
     public Cursor query(SupportSQLiteQuery supportQuery, android.os.CancellationSignal signal) {
-        if(signal != null){
-            final CancellationSignal supportCancellationSignal = supportCancellationSignal= new CancellationSignal();
+        if (signal != null) {
+            final CancellationSignal supportCancellationSignal = new CancellationSignal();
             signal.setOnCancelListener(new android.os.CancellationSignal.OnCancelListener() {
                 @Override
                 public void onCancel() {
@@ -1360,7 +1360,7 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
             });
             return query(supportQuery, supportCancellationSignal);
         } else {
-            return query(supportQuery, null);
+            return query(supportQuery, (CancellationSignal) null);
         }
     }
 


### PR DESCRIPTION
Providing a null android.os.CancellationSignal argument to SupportSQLiteDatabase.query(SupportSQLiteQuery, android.os.CancellationSignal) should not result in a NPE, but just skip cancellation.

Fixes build issues in #108 