### PR TITLE
Correctly recognise SELECT statements that start with WITH

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteStatementType.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteStatementType.java
@@ -66,7 +66,8 @@ class SQLiteStatementType {
         }
         String prefixSql = sql.substring(0, 3);
 
-        if (prefixSql.equalsIgnoreCase("SEL")) {
+        if (prefixSql.equalsIgnoreCase("SEL")
+                || prefixSql.equalsIgnoreCase("WIT")) {
             return STATEMENT_SELECT;
         }
         if (prefixSql.equalsIgnoreCase("INS")


### PR DESCRIPTION
Starting with 3.8.3 (2014-02-03) SQLite supports Common Table Expressions
https://www.sqlite.org/lang_with.html
SQLiteStatementType should recognise SELECT statements that begin with this clause.

From what I can tell, the only consequence of WITH not having been recognized as a `SELECT` statement before now is that in `SQLiteConnection.acquirePreparedStatement` prepared statements are only cached if they are known to be a `SELECT` or an `UPDATE`, so this change will fix it so that CTE `SELECT` prepared statements are now cached.