### PR TITLE
Bump to sqlite version 3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+## 3.31.0
+- [SQLite 3.31.0](http://sqlite.org/releaselog/3_31_0.html)
+
 ## 3.30.1
 - [SQLite 3.30.0](http://sqlite.org/releaselog/3_30_0.html)
 - [SQLite 3.30.1](http://sqlite.org/releaselog/3_30_1.html)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use new SQLite features:
 - **[Common Table expressions](https://www.sqlite.org/lang_with.html)**
 - **[Indexes on expressions](https://www.sqlite.org/expridx.html)**
 - **[Full Text Search 5](https://www.sqlite.org/fts5.html)**
+- **[Generated Columns](https://www.sqlite.org/gencol.html)**
 
 Performance
 -----------

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Use new SQLite features:
 - **[JSON1 extension](https://www.sqlite.org/json1.html)**
 - **[Common Table expressions](https://www.sqlite.org/lang_with.html)**
 - **[Indexes on expressions](https://www.sqlite.org/expridx.html)**
+- **[Full Text Search 5](https://www.sqlite.org/fts5.html)**
 
 Performance
 -----------
@@ -45,7 +46,7 @@ Usage
 
 ```gradle
 dependencies {
-    implementation 'io.requery:sqlite-android:3.30.1'
+    implementation 'io.requery:sqlite-android:3.31.0'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ CPU Architectures
 
 The native library is built for the following CPU architectures:
 
-- `armeabi-v7a`
-- `arm64-v8a`
-- `x86`
-- `x86_64`
+- `armeabi-v7a` ~1.4 MB
+- `arm64-v8a` ~2 MB
+- `x86` ~2.1 MB
+- `x86_64` ~2.1 MB
 
 However you may not want to include all binaries in your apk. You can exclude certain variants by
 using `packagingOptions`:
@@ -95,7 +95,7 @@ android {
 }
 ```
 
-The size of the artifacts with only the armeabi-v7a binary is **~600kb**. In general you can use
+The size of the artifacts with only the armeabi-v7a binary is **~1.4 MB**. In general you can use
 armeabi-v7a on the majority of Android devices including Intel Atom which provides a native
 translation layer, however performance under the translation layer is worse than using the x86
 binary.

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'de.undercouch.download'
 
 group = 'io.requery'
-version = '3.30.1'
+version = '3.31.0'
 description = 'Android SQLite compatibility library'
 
 android {
@@ -60,7 +60,7 @@ publish.dependsOn "assembleRelease"
 bintrayUpload.dependsOn "assembleRelease"
 
 ext {
-    sqliteDistributionUrl = 'https://sqlite.org/2019/sqlite-amalgamation-3300100.zip'
+    sqliteDistributionUrl = 'https://sqlite.org/2020/sqlite-amalgamation-3310000.zip'
     pomXml = {
         resolveStrategy = DELEGATE_FIRST
         name project.name


### PR DESCRIPTION
Build/deploy was not tested, but all links where checked.