### PR TITLE
getWindowSizeKb

### DIFF
--- a/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
@@ -26,6 +26,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -103,5 +104,21 @@ public class CursorWindowTest {
         Arrays.fill(blob, value);
         assertTrue(window.putBlob(blob, 0, 6));
         assertTrue(Arrays.equals(blob, window.getBlob(0, 6)));
+    }
+
+
+
+    @SmallTest
+    @Test
+    public void testConstructorDifferentSize() {
+        CursorWindow window = new CursorWindow("big", 8);
+        assertEquals("big", window.getName());
+        assertEquals(0, window.getStartPosition());
+        try {
+            doTestValues(window);
+            fail("For window of size 8, the test should fail.");
+        } catch (Exception e) {
+        }
+        window.close();
     }
 }

--- a/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
@@ -44,6 +44,7 @@ public class CursorWindowTest {
         CursorWindow window = new CursorWindow("MyWindow");
         assertEquals("MyWindow", window.getName());
         assertEquals(0, window.getStartPosition());
+        assertEquals(2048 * 1024, window.getWindowSizeBytes());
         window.close();
     }
 
@@ -53,6 +54,7 @@ public class CursorWindowTest {
         CursorWindow window = new CursorWindow("");
         assertEquals("<unnamed>", window.getName());
         assertEquals(0, window.getStartPosition());
+        assertEquals(2048 * 1024, window.getWindowSizeBytes());
         window.close();
     }
 
@@ -62,6 +64,7 @@ public class CursorWindowTest {
         CursorWindow window = new CursorWindow(null);
         assertEquals("<unnamed>", window.getName());
         assertEquals(0, window.getStartPosition());
+        assertEquals(2048 * 1024, window.getWindowSizeBytes());
         window.close();
     }
 
@@ -114,6 +117,7 @@ public class CursorWindowTest {
         CursorWindow window = new CursorWindow("big", 8);
         assertEquals("big", window.getName());
         assertEquals(0, window.getStartPosition());
+        assertEquals(8, window.getWindowSizeBytes());
         try {
             doTestValues(window);
             fail("For window of size 8, the test should fail.");

--- a/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
@@ -500,4 +500,8 @@ public class CursorWindow extends SQLiteClosable {
     public String toString() {
         return getName() + " {" + Long.toHexString(mWindowPtr) + "}";
     }
+
+    public int getWindowSizeBytes() {
+        return mWindowSizeBytes;
+    }
 }

--- a/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
@@ -33,7 +33,7 @@ public class CursorWindow extends SQLiteClosable {
     /** The cursor window size. resource xml file specifies the value in kB.
      * convert it to bytes here by multiplying with 1024.
      */
-    private static final int sCursorWindowSize =
+    private static final int sDefaultCursorWindowSize =
         WINDOW_SIZE_KB * 1024;
 
     /**
@@ -80,10 +80,10 @@ public class CursorWindow extends SQLiteClosable {
     public CursorWindow(String name) {
         mStartPos = 0;
         mName = name != null && name.length() != 0 ? name : "<unnamed>";
-        mWindowPtr = nativeCreate(mName, sCursorWindowSize);
+        mWindowPtr = nativeCreate(mName, sDefaultCursorWindowSize);
         if (mWindowPtr == 0) {
             throw new CursorWindowAllocationException("Cursor window allocation of " +
-                    (sCursorWindowSize / 1024) + " kb failed. ");
+                    (sDefaultCursorWindowSize / 1024) + " kb failed. ");
         }
     }
 

--- a/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/CursorWindow.java
@@ -35,6 +35,7 @@ public class CursorWindow extends SQLiteClosable {
      */
     private static final int sDefaultCursorWindowSize =
         WINDOW_SIZE_KB * 1024;
+    private final int mWindowSizeBytes;
 
     /**
      * The native CursorWindow object pointer.  (FOR INTERNAL USE ONLY)
@@ -69,6 +70,14 @@ public class CursorWindow extends SQLiteClosable {
     private static native String nativeGetName(long windowPtr);
 
     /**
+     * Creates a new empty cursor with default cursor size (currently 2MB)
+     */
+    public CursorWindow(String name) {
+        this(name, sDefaultCursorWindowSize);
+    }
+
+
+    /**
      * Creates a new empty cursor window and gives it a name.
      * <p>
      * The cursor initially has no rows or columns.  Call {@link #setNumColumns(int)} to
@@ -76,14 +85,29 @@ public class CursorWindow extends SQLiteClosable {
      * </p>
      *
      * @param name The name of the cursor window, or null if none.
+     * @param windowSizeBytes Size of cursor window in bytes.
+     *
+     * Note: Memory is dynamically allocated as data rows are added to
+     * the window. Depending on the amount of data stored, the actual
+     * amount of memory allocated can be lower than specified size,
+     * but cannot exceed it. Value is a non-negative number of bytes.
      */
-    public CursorWindow(String name) {
+    public CursorWindow(String name, int windowSizeBytes) {
+        /* In
+         https://developer.android.com/reference/android/database/CursorWindow#CursorWindow(java.lang.String,%20long)
+         windowSizeBytes is long. However windowSizeBytes is
+         eventually transformed into a size_t in cpp, and I can not
+         guarantee that long->size_t would be possible. I thus keep
+         int. This means that we can create cursor of size up to 4GiB
+         while upstream can theoretically create cursor of size up to
+         16 EiB. It is probably an acceptable restriction.*/
         mStartPos = 0;
+        mWindowSizeBytes = windowSizeBytes;
         mName = name != null && name.length() != 0 ? name : "<unnamed>";
-        mWindowPtr = nativeCreate(mName, sDefaultCursorWindowSize);
+        mWindowPtr = nativeCreate(mName, windowSizeBytes);
         if (mWindowPtr == 0) {
             throw new CursorWindowAllocationException("Cursor window allocation of " +
-                    (sDefaultCursorWindowSize / 1024) + " kb failed. ");
+                    (windowSizeBytes / 1024) + " kb failed. ");
         }
     }
 


### PR DESCRIPTION
The window size should ideally be an internal value. Alas, if a query
returns a column whose size is more than this window size, an
exception is raised. Thus, the only solution known currently is to
split the data in portions whose size are less than the actual window
size.

This can be done by looking at requery's code while splitting the
database content. However, I believe that being able to access this
value would be quite better, as it would allow the software using this
library to simply use `(int) (getWindowSizeKb * .9)` and ensure that
the data fits in the query, even if at some point this size change.

Ideally, I'd even prefer to be allowed to change this number when I
create a cursor, but I don't understand the codebase enough to know
how to do it safely, and how to test this library with the software I
contribute to (Ankidroid)