### PR TITLE
Fix CursorFactory is not respected when querying via Support API

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteDatabase.java
@@ -1384,7 +1384,11 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
             public Cursor newCursor(SQLiteDatabase db, SQLiteCursorDriver masterQuery,
                                     String editTable, SQLiteQuery query) {
                 supportQuery.bindTo(query);
-                return new SQLiteCursor(masterQuery, editTable, query);
+                if (mCursorFactory == null) {
+                    return new SQLiteCursor(masterQuery, editTable, query);
+                } else {
+                    return mCursorFactory.newCursor(db, masterQuery, editTable, query);
+                }
             }
         }, supportQuery.getSql(), new String[0], null, signal);
     }


### PR DESCRIPTION
Customized `CursorFactory` can be passed to query methods that are specified in the original Android SDK, namely:
- `SQLiteDatabase#queryWithFactory(...)`
- `SQLiteDatabase#rawQueryWithFactory(...)`

Both respect `SQLiteDatabase#mCursorFactory` that is passed in the constructor.

Unlike those, query methods from Support library don't accept customized `CursorFactory`. Currently, we pass new instance of `CursorFactory` to facilitate binding statement for `SupportSQLiteQuery`, avoiding `SQLiteDatabase#mCursorFactory` completely. This patch fixes that behavior. Now `SQLiteDatabase#mCursorFactory` (if any) will be used after `SupportSQLiteQuery` statement is bounded.