### PR TITLE
Make repository jitpack.io compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,24 @@ versions.
 Usage
 -----
 
+Follow the guidelines from [jitpack.io](https://jitpack.io) to add the JitPack repository to your build file if you have not.
+
+Typically, this means an edit to your `build.gradle` file to add a new `repository` definition in the `allprojects` block, like this:
+
+```gradle
+	allprojects {
+		repositories {
+			...
+			maven { url 'https://jitpack.io' }
+		}
+	}
+```
+
+Then add the sqlite-android artifact from this repository as a dependency:
+
 ```gradle
 dependencies {
-    implementation 'io.requery:sqlite-android:3.35.4'
+    implementation 'com.github.requery:sqlite-android:3.35.4'
 }
 ```
 Then change usages of `android.database.sqlite.SQLiteDatabase` to

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -13,7 +13,7 @@ description = 'Android SQLite compatibility library'
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
-    ndkVersion '21.4.7075529'
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         minSdkVersion 14
@@ -107,19 +107,28 @@ if (localProperties.exists()) {
 }
 
 task sourceJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
+    android.libraryVariants.all { variant ->
+        if (variant.name == 'release') {
+            owner.classpath += variant.javaCompileProvider.get().classpath
+        }
+    }
+    exclude '**/R.html', '**/R.*.html', '**/index.html'
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+
     failOnError false
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 
@@ -132,25 +141,25 @@ publishing {
             artifact "build/outputs/aar/${project.name}-release.aar"
             artifact sourceJar
             artifact javadocJar
-            pom {
-                name = project.name
-                description = project.description
-                url = 'https://github.com/requery/sqlite-android'
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/requery/sqlite-android.git'
-                    url = 'https://github.com/requery/sqlite-android'
-                }
-            }
+//            pom {
+//                name = project.name
+//                description = project.description
+//                url = 'https://github.com/requery/sqlite-android'
+//                licenses {
+//                    license {
+//                        name = 'The Apache License, Version 2.0'
+//                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+//                    }
+//                }
+//                scm {
+//                    connection = 'scm:git:git://github.com/requery/sqlite-android.git'
+//                    url = 'https://github.com/requery/sqlite-android'
+//                }
+//            }
             pom.withXml {
                 asNode().children().last() + project.pomXml
                 def dependencies = asNode().appendNode('dependencies')
-                configurations.compile.allDependencies.each {
+                configurations.compile.allDependencies.all {
                     def dependency = dependencies.appendNode('dependency')
                     dependency.appendNode('groupId', it.group)
                     dependency.appendNode('artifactId', it.name)
@@ -160,15 +169,15 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            credentials {
-                username properties.getProperty('sonatype.username')
-                password properties.getProperty('sonatype.password')
-            }
-        }
-    }
+//    repositories {
+//        maven {
+//            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+//            credentials {
+//                username properties.getProperty('sonatype.username')
+//                password properties.getProperty('sonatype.password')
+//            }
+//        }
+//    }
 }
 
 publish.dependsOn "assembleRelease"


### PR DESCRIPTION
The repository was suprisingly close to working on jitpack

- the ndkVersion jitpack uses is a little different
- I *personally* bumped the version of the library itself for testing, that's bogus for the PR and I'll follow this with an annotation in the PR to change it
- the javadoc task wasn't right and couldn't find symbols etc, I copy-pasted in a task from another library I maintain

Fixes #140 

https://jitpack.io/com/github/mikehardy/sqlite-android/3.35.1.1/build.log

Takes about 10 minutes for jitpack to build the artifact starting from the first time someone requests it.

You can already depend on this artifact and try it if you like:

```groovy
    implementation 'com.github.mikehardy:sqlite-android:3.35.1.1'
```