### PR TITLE
3.38.4 patch for available NDK version

### DIFF
--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -13,7 +13,7 @@ description = 'Android SQLite compatibility library'
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
-    ndkVersion '21.1.6352462'
+    ndkVersion '22.1.7171670'
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
Looks like the build machine has a different ndk version installed locally causing it to fail:
- https://jitpack.io/com/github/requery/sqlite-android/3.38.4/build.log

Could you try running this on the build machine @npurushe ?

(That should hopefully address https://github.com/requery/sqlite-android/issues/155#issuecomment-1119365159 )