### PR TITLE
Remove STL dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ CPU Architectures
 
 The native library is built for the following CPU architectures:
 
-- `armeabi-v7a` ~1.4 MB
-- `arm64-v8a` ~2 MB
-- `x86` ~2.1 MB
-- `x86_64` ~2.1 MB
+- `armeabi-v7a` ~1.2 MB
+- `arm64-v8a` ~1.7 MB
+- `x86` ~1.7 MB
+- `x86_64` ~1.8 MB
 
 However you may not want to include all binaries in your apk. You can exclude certain variants by
 using `packagingOptions`:
@@ -97,7 +97,7 @@ android {
 }
 ```
 
-The size of the artifacts with only the armeabi-v7a binary is **~1.4 MB**. In general you can use
+The size of the artifacts with only the armeabi-v7a binary is **~1.2 MB**. In general you can use
 armeabi-v7a on the majority of Android devices including Intel Atom which provides a native
 translation layer, however performance under the translation layer is worse than using the x86
 binary.
@@ -146,6 +146,7 @@ Changes
 - Made the AOSP code (mostly) warning free but still mergable from source
 - Deprecated classes/methods removed
 - Loadable extension support
+- STL dependency removed
 
 License
 -------

--- a/sqlite-android/src/main/jni/Application.mk
+++ b/sqlite-android/src/main/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_STL:=c++_static
+APP_STL:=none
 APP_OPTIM := release
 APP_ABI := armeabi-v7a,arm64-v8a,x86,x86_64
 NDK_TOOLCHAIN_VERSION := clang

--- a/sqlite-android/src/main/jni/sqlite/CursorWindow.cpp
+++ b/sqlite-android/src/main/jni/sqlite/CursorWindow.cpp
@@ -27,16 +27,18 @@
 
 namespace android {
 
-CursorWindow::CursorWindow(const std::string& name, void* data, size_t size, bool readOnly) :
-        mName(name), mData(data), mSize(size), mReadOnly(readOnly) {
+CursorWindow::CursorWindow(const char* name, void* data, size_t size, bool readOnly) :
+        mData(data), mSize(size), mReadOnly(readOnly) {
+    mName = strdup(name);
     mHeader = static_cast<Header*>(mData);
 }
 
 CursorWindow::~CursorWindow() {
+    free(mName);
     free(mData);
 }
 
-status_t CursorWindow::create(const std::string& name, size_t size, CursorWindow** outWindow) {
+status_t CursorWindow::create(const char* name, size_t size, CursorWindow** outWindow) {
     status_t result;
     void* data = malloc(size);
     if (!data) {
@@ -54,6 +56,7 @@ status_t CursorWindow::create(const std::string& name, size_t size, CursorWindow
         *outWindow = window;
         return OK;
     }
+    delete window;
     return result;
 }
 

--- a/sqlite-android/src/main/jni/sqlite/CursorWindow.h
+++ b/sqlite-android/src/main/jni/sqlite/CursorWindow.h
@@ -23,7 +23,6 @@
 #include <stdint.h>
 
 #include "Errors.h"
-#include <string>
 
 #if LOG_NDEBUG
 
@@ -50,7 +49,7 @@ namespace android {
  * Strings are stored in UTF-8.
  */
 class CursorWindow {
-    CursorWindow(const std::string& name, void* data, size_t size, bool readOnly);
+    CursorWindow(const char* name, void* data, size_t size, bool readOnly);
 
 public:
     /* Field types. */
@@ -80,9 +79,9 @@ public:
 
     ~CursorWindow();
 
-    static status_t create(const std::string& name, size_t size, CursorWindow** outCursorWindow);
+    static status_t create(const char* name, size_t size, CursorWindow** outCursorWindow);
 
-    inline std::string name() { return mName; }
+    inline const char* name() { return mName; }
     inline size_t size() { return mSize; }
     inline size_t freeSpace() { return mSize - mHeader->freeOffset; }
     inline uint32_t getNumRows() { return mHeader->numRows; }
@@ -156,7 +155,7 @@ private:
         uint32_t nextChunkOffset;
     };
 
-    std::string mName;
+    char* mName;
     void* mData;
     size_t mSize;
     bool mReadOnly;

--- a/sqlite-android/src/main/jni/sqlite/JNIHelp.h
+++ b/sqlite-android/src/main/jni/sqlite/JNIHelp.h
@@ -102,12 +102,6 @@ void jniSetFileDescriptorOfFD(C_JNIEnv* env, jobject fileDescriptor, int value);
  */
 jobject jniGetReferent(C_JNIEnv* env, jobject ref);
 
-/*
- * Log a message and an exception.
- * If exception is NULL, logs the current exception in the JNI environment.
- */
-void jniLogException(C_JNIEnv* env, int priority, const char* tag, jthrowable exception);
-
 #ifdef __cplusplus
 }
 #endif
@@ -165,10 +159,6 @@ inline void jniSetFileDescriptorOfFD(JNIEnv* env, jobject fileDescriptor, int va
 
 inline jobject jniGetReferent(JNIEnv* env, jobject ref) {
     return jniGetReferent(&env->functions, ref);
-}
-
-inline void jniLogException(JNIEnv* env, int priority, const char* tag, jthrowable exception = NULL) {
-    jniLogException(&env->functions, priority, tag, exception);
 }
 
 #endif

--- a/sqlite-android/src/main/jni/sqlite/android_database_CursorWindow.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_CursorWindow.cpp
@@ -23,7 +23,7 @@
 #include <jni.h>
 #include <JNIHelp.h>
 #include <stdio.h>
-#include <string>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "CursorWindow.h"
@@ -51,12 +51,11 @@ static void throwUnknownTypeException(JNIEnv * env, jint type) {
 }
 
 static jlong nativeCreate(JNIEnv* env, jclass clazz, jstring nameObj, jint cursorWindowSize) {
+    CursorWindow* window;
     const char* nameStr = env->GetStringUTFChars(nameObj, NULL);
-    std::string name(nameStr);
+    status_t status = CursorWindow::create(nameStr, cursorWindowSize, &window);
     env->ReleaseStringUTFChars(nameObj, nameStr);
 
-    CursorWindow* window;
-    status_t status = CursorWindow::create(name, cursorWindowSize, &window);
     if (status || !window) {
         ALOGE("Could not allocate CursorWindow of size %d due to error %d.",
         cursorWindowSize, status);
@@ -77,7 +76,7 @@ static void nativeDispose(JNIEnv* env, jclass clazz, jlong windowPtr) {
 
 static jstring nativeGetName(JNIEnv* env, jclass clazz, jlong windowPtr) {
     CursorWindow* window = reinterpret_cast<CursorWindow*>(windowPtr);
-    return env->NewStringUTF(window->name().c_str());
+    return env->NewStringUTF(window->name());
 }
 
 static void nativeClear(JNIEnv * env, jclass clazz, jlong windowPtr) {

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteConnection.cpp
@@ -20,6 +20,7 @@
 #include <jni.h>
 #include <sys/mman.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <assert.h>
 
@@ -28,8 +29,6 @@
 #include "ALog-priv.h"
 #include "android_database_SQLiteCommon.h"
 #include "CursorWindow.h"
-
-#include <string>
 
 // Set to 1 to use UTF16 storage for localized indexes.
 #define UTF16_STORAGE 0
@@ -72,27 +71,35 @@ static struct {
 struct SQLiteConnection {
     sqlite3* const db;
     const int openFlags;
-    std::string path;
-    std::string label;
+    char* path;
+    char* label;
 
     volatile bool canceled;
 
-    SQLiteConnection(sqlite3* db, int openFlags, const std::string& path, const std::string& label) :
-        db(db), openFlags(openFlags), path(path), label(label), canceled(false) { }
+    SQLiteConnection(sqlite3* db, int openFlags, const char* path_, const char* label_) :
+        db(db), openFlags(openFlags), canceled(false) {
+        path = strdup(path_);
+        label = strdup(label_);
+    }
+
+    ~SQLiteConnection() {
+        free(path);
+        free(label);
+    }
 };
 
 // Called each time a statement begins execution, when tracing is enabled.
 static void sqliteTraceCallback(void *data, const char *sql) {
     SQLiteConnection* connection = static_cast<SQLiteConnection*>(data);
     ALOG(LOG_VERBOSE, SQLITE_TRACE_TAG, "%s: \"%s\"\n",
-            connection->label.c_str(), sql);
+            connection->label, sql);
 }
 
 // Called each time a statement finishes execution, when profiling is enabled.
 static void sqliteProfileCallback(void *data, const char *sql, sqlite3_uint64 tm) {
     SQLiteConnection* connection = static_cast<SQLiteConnection*>(data);
     ALOG(LOG_VERBOSE, SQLITE_PROFILE_TAG, "%s: \"%s\" took %0.3f ms\n",
-            connection->label.c_str(), sql, tm * 0.000001f);
+            connection->label, sql, tm * 0.000001f);
 }
 
 // Called after each SQLite VM instruction when cancelation is enabled.
@@ -130,21 +137,20 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
         jstring labelStr, jboolean enableTrace, jboolean enableProfile) {
 
     const char* pathChars = env->GetStringUTFChars(pathStr, NULL);
-    std::string path(pathChars);
-    env->ReleaseStringUTFChars(pathStr, pathChars);
-
     const char* labelChars = env->GetStringUTFChars(labelStr, NULL);
-    std::string label(labelChars);
-    env->ReleaseStringUTFChars(labelStr, labelChars);
 
     sqlite3* db;
-    int err = sqlite3_open_v2(path.c_str(), &db, openFlags, NULL);
+    int err = sqlite3_open_v2(pathChars, &db, openFlags, NULL);
     if (err != SQLITE_OK) {
+        env->ReleaseStringUTFChars(pathStr, pathChars);
+        env->ReleaseStringUTFChars(labelStr, labelChars);
         throw_sqlite3_exception_errcode(env, err, "Could not open database");
         return 0;
     }
     err = sqlite3_create_collation(db, "localized", SQLITE_UTF8, 0, coll_localized);
     if (err != SQLITE_OK) {
+        env->ReleaseStringUTFChars(pathStr, pathChars);
+        env->ReleaseStringUTFChars(labelStr, labelChars);
         throw_sqlite3_exception_errcode(env, err, "Could not register collation");
         sqlite3_close(db);
         return 0;
@@ -152,6 +158,8 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
 
     // Check that the database is really read/write when that is what we asked for.
     if ((openFlags & SQLITE_OPEN_READWRITE) && sqlite3_db_readonly(db, NULL)) {
+        env->ReleaseStringUTFChars(pathStr, pathChars);
+        env->ReleaseStringUTFChars(labelStr, labelChars);
         throw_sqlite3_exception(env, db, "Could not open the database in read/write mode.");
         sqlite3_close(db);
         return 0;
@@ -160,6 +168,8 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
     // Set the default busy handler to retry automatically before returning SQLITE_BUSY.
     err = sqlite3_busy_timeout(db, BUSY_TIMEOUT_MS);
     if (err != SQLITE_OK) {
+        env->ReleaseStringUTFChars(pathStr, pathChars);
+        env->ReleaseStringUTFChars(labelStr, labelChars);
         throw_sqlite3_exception(env, db, "Could not set busy timeout");
         sqlite3_close(db);
         return 0;
@@ -169,6 +179,8 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
 #if 0
     err = register_android_functions(db, UTF16_STORAGE);
     if (err) {
+        env->ReleaseStringUTFChars(pathStr, pathChars);
+        env->ReleaseStringUTFChars(labelStr, labelChars);
         throw_sqlite3_exception(env, db, "Could not register Android SQL functions.");
         sqlite3_close(db);
         return 0;
@@ -176,7 +188,10 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
 #endif
 
     // Create wrapper object.
-    SQLiteConnection* connection = new SQLiteConnection(db, openFlags, path, label);
+    SQLiteConnection* connection = new SQLiteConnection(db, openFlags, pathChars, labelChars);
+    ALOGV("Opened connection %p with label '%s'", db, labelChars);
+    env->ReleaseStringUTFChars(pathStr, pathChars);
+    env->ReleaseStringUTFChars(labelStr, labelChars);
 
     // Enable tracing and profiling if requested.
     if (enableTrace) {
@@ -186,7 +201,6 @@ static jlong nativeOpen(JNIEnv* env, jclass clazz, jstring pathStr, jint openFla
         sqlite3_profile(db, &sqliteProfileCallback, connection);
     }
 
-    ALOGV("Opened connection %p with label '%s'", db, label.c_str());
     return reinterpret_cast<jlong>(connection);
 }
 

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteFunction.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteFunction.cpp
@@ -11,8 +11,6 @@
 #include "ALog-priv.h"
 #include "android_database_SQLiteCommon.h"
 
-#include <string>
-
 namespace android {
 
 /* Returns the sqlite3_value for the given arg of the given function.


### PR DESCRIPTION
This patch removes STL dependency of the library and turns resulting `sqlite-android-debug.aar` from 3,811,548 bytes to 3,450,656 bytes.

The only STL use on the project was `std::string` which was relatively easy to get rid of but sure the change needs to be tested whether it doesn't change anything (tbh I didn't test the resulting binary yet)

Given the size decrease hopefully reviewing the change is worth to hassle.

Thanks!

Update: in 3.39.0 changes 3,801,068 bytes to 3,442,739 bytes