### PR TITLE
Fix cursor window size test to check for failure correctly

### DIFF
--- a/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
+++ b/sqlite-android/src/androidTest/java/io/requery/android/database/CursorWindowTest.java
@@ -112,17 +112,17 @@ public class CursorWindowTest {
 
 
     @SmallTest
-    @Test
+    @Test(expected = AssertionError.class)
     public void testConstructorDifferentSize() {
         CursorWindow window = new CursorWindow("big", 8);
         assertEquals("big", window.getName());
         assertEquals(0, window.getStartPosition());
         assertEquals(8, window.getWindowSizeBytes());
         try {
+            // For window of size 8, the test should fail
             doTestValues(window);
-            fail("For window of size 8, the test should fail.");
-        } catch (Exception e) {
+        } finally {
+            window.close();
         }
-        window.close();
     }
 }


### PR DESCRIPTION
Currently the test always fails and as `AssertionError` isn't inherited from `Exception` current mechanism to catch the failure gracefully is broken itself so this fixes it by using JUnit 4's `@Test(expected = AssertionError.class)`.