### PR TITLE
Change includes to indicate local header files.

### DIFF
--- a/sqlite-android/src/main/jni/sqlite/android_database_CursorWindow.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_CursorWindow.cpp
@@ -21,11 +21,11 @@
 
 #include <inttypes.h>
 #include <jni.h>
-#include <JNIHelp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "JNIHelp.h"
 #include "CursorWindow.h"
 #include "android_database_SQLiteCommon.h"
 

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteCommon.h
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteCommon.h
@@ -19,7 +19,7 @@
 #define _ANDROID_DATABASE_SQLITE_COMMON_H
 
 #include <jni.h>
-#include <JNIHelp.h>
+#include "JNIHelp.h"
 
 #include <sqlite3.h>
 

--- a/sqlite-android/src/main/jni/sqlite/android_database_SQLiteGlobal.cpp
+++ b/sqlite-android/src/main/jni/sqlite/android_database_SQLiteGlobal.cpp
@@ -18,7 +18,7 @@
 #define LOG_TAG "SQLiteGlobal"
 
 #include <jni.h>
-#include <JNIHelp.h>
+#include "JNIHelp.h"
 #include "ALog-priv.h"
 
 #include <sqlite3.h>


### PR DESCRIPTION
While this is mostly a convention, some build systems do make a difference between angle quotes and double quotation marks, where double quotes indicate a local file and angle quotes normally indicate a standard library header file.