### PR TITLE
Add missing SQLiteUpdateHook to fix broken build introduced by #194

### DIFF
--- a/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteUpdateHook.java
+++ b/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteUpdateHook.java
@@ -1,0 +1,5 @@
+package io.requery.android.database.sqlite;
+
+public interface SQLiteUpdateHook {
+    void onUpdateFromNative(int operationType, String databaseName, String tableName, long rowId);
+}


### PR DESCRIPTION
#194 is missing one commit (https://github.com/requery/sqlite-android/compare/master...BuildHero:sqlite-android:feat/sqlite3_update_hook). This adds the missing commit and fixes the build.