### PR TITLE
Support 16 KB page sizes

### DIFF
--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 android {
     buildToolsVersion = "34.0.0"
-    ndkVersion "26.1.10909125"
+    ndkVersion "28.0.13004108"
 
     compileSdk 34
 


### PR DESCRIPTION
As described [here](https://github.com/requery/sqlite-android/issues/195), Android 15 requires support for [16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).

NDK 28 handles this out of the box. Alternatively, you can set the required arguments as described [here](https://developer.android.com/guide/practices/page-sizes#compile-r26-lower). I verified the output shared library using [check_elf_alignment.sh](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) and the result was `ELF Verification Successful`.

It is possible to test the .aab using [JitPack](https://jitpack.io/#Zellius/sqlite-android/16kb_page_size_support-SNAPSHOT) by adding the following dependency to your Gradle file.

```gradle
dependencies {
   implementation 'com.github.Zellius:sqlite-android:16kb_page_size_support-SNAPSHOT'
}
```